### PR TITLE
Improved error message for missing TARGETDIR.

### DIFF
--- a/src/builder.vala
+++ b/src/builder.vala
@@ -284,7 +284,7 @@ namespace Wixl {
 
             if (dir.parent.get_type () == typeof (WixProduct)) {
                 if (dir.Id != "TARGETDIR")
-                    throw new Wixl.Error.FAILED ("Invalid root directory");
+                    throw new Wixl.Error.FAILED ("Invalid root directory. All Directory nodes need to have a comon parent: <Directory Id='TARGETDIR' Name='SourceDir'>");
                 db.table_directory.add (dir.Id, null, defaultdir);
             } else if (dir.parent.get_type () == typeof (WixDirectory)) {
                 var parent = dir.parent as WixDirectory;

--- a/src/builder.vala
+++ b/src/builder.vala
@@ -284,7 +284,7 @@ namespace Wixl {
 
             if (dir.parent.get_type () == typeof (WixProduct)) {
                 if (dir.Id != "TARGETDIR")
-                    throw new Wixl.Error.FAILED ("Invalid root directory. All Directory nodes need to have a comon parent: <Directory Id='TARGETDIR' Name='SourceDir'>");
+                    throw new Wixl.Error.FAILED ("Invalid root directory. The root product <Directory> must be: <Directory Id='TARGETDIR' Name='SourceDir'>");
                 db.table_directory.add (dir.Id, null, defaultdir);
             } else if (dir.parent.get_type () == typeof (WixDirectory)) {
                 var parent = dir.parent as WixDirectory;


### PR DESCRIPTION
If there is no <Directory> node with the Id='TARGETDIR' found as common parent of all other <Directory> nodes, wixl will just fail with the error "Invalid root directory" which might leave the user a bit clueless about what to do.
This should provide a bit more information to the user.